### PR TITLE
build: Improve Makefile for development and Docker workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,55 @@
-.PHONY: help build run test docker-build docker-run docker-stop clean
+.PHONY: help build run test docker-build docker-run docker-stop docker-logs clean
+
+BINARY_NAME=spotokn
+DOCKER_IMAGE=ghcr.io/botxlab/spotokn:latest
+DOCKERFILE=docker/Dockerfile
 
 help:
 	@echo "Available commands:"
-	@echo "  make build        - Build the Go binary"
-	@echo "  make run          - Run the service locally"
-	@echo "  make test         - Run tests"
-	@echo "  make docker-build - Build Docker image"
-	@echo "  make docker-run   - Run with Docker Compose"
-	@echo "  make docker-stop  - Stop Docker containers"
-	@echo "  make clean        - Clean build artifacts"
+	@echo "  make build         - Build the Go binary"
+	@echo "  make run           - Run the service locally"
+	@echo "  make test          - Run tests"
+	@echo "  make docker-build  - Build Docker image"
+	@echo "  make docker-push   - Push Docker image to GHCR"
+	@echo "  make docker-run    - Run with Docker Compose"
+	@echo "  make docker-stop   - Stop Docker containers"
+	@echo "  make docker-logs   - View container logs"
+	@echo "  make clean         - Clean build artifacts & stop containers"
 
+# Build Go binary from cmd/spotokn
 build:
-	go build -o spotokn .
+	go build -o $(BINARY_NAME) ./cmd/spotokn
 
+# Run locally (non-Docker)
 run:
-	go run .
+	go run ./cmd/spotokn
 
+# Run tests
 test:
 	go test -v ./...
 
+# Build Docker image using docker/Dockerfile
 docker-build:
-	docker build -t spotokn:latest .
+	docker build -t $(DOCKER_IMAGE) -f $(DOCKERFILE) .
 
+# Push image to GHCR
+docker-push:
+	docker push $(DOCKER_IMAGE)
+
+# Run Docker Compose
 docker-run:
-	docker compose up -d
+	docker compose -f docker/docker-compose.yml up -d
 
+# Stop containers
 docker-stop:
-	docker compose down
+	docker compose -f docker/docker-compose.yml down
 
+# Logs
 docker-logs:
-	docker compose logs -f
+	docker compose -f docker/docker-compose.yml logs -f
 
+# Clean build artifacts
 clean:
-	rm -f spotokn
-	docker compose down -v
-	docker rmi spotokn:latest 2>/dev/null || true
+	rm -f $(BINARY_NAME)
+	docker compose -f docker/docker-compose.yml down -v || true
+	docker rmi $(DOCKER_IMAGE) 2>/dev/null || true


### PR DESCRIPTION
This commit refactors the Makefile to enhance clarity, maintainability, and functionality for both local development and Docker workflows.

Key changes include:
*   **Centralized Configuration:** Introduced `BINARY_NAME`, `DOCKER_IMAGE`, and `DOCKERFILE` variables to make the Makefile more configurable and reduce hardcoding.
*   **Explicit Build Paths:** Updated `build` and `run` targets to explicitly reference the Go main package at `./cmd/spotokn`, ensuring correct execution when the project structure might evolve.
*   **New Docker Commands:** Added `docker-push` for publishing images to GHCR and `docker-logs` for easily viewing container output.
*   **Robust Docker Compose:** Modified `docker-build`, `docker-run`, `docker-stop`, and `docker-logs` to explicitly use `docker/docker-compose.yml` and leverage the new variables for image tagging.
*   **Enhanced Clean-up:** The `clean` target now uses variables and includes `|| true` for Docker commands to prevent failures if containers or images don't exist.
*   **Improved Documentation:** Added inline comments and updated the `help` message for better understanding of available commands and their purpose.