### PR TITLE
Add /api/query endpoint for Spotify hash retrieval

### DIFF
--- a/cmd/spotokn/main.go
+++ b/cmd/spotokn/main.go
@@ -1,24 +1,26 @@
 package main
 
-import (
-    "context"
-    "encoding/json"
-    "net/http"
-    "os"
-    "os/signal"
-    "strconv"
-    "syscall"
-    "time"
 
-    "github.com/botxlab/spotokn/internal"
+import (
+       "context"
+       "encoding/json"
+       "net/http"
+       "os"
+       "os/signal"
+       "strconv"
+       "syscall"
+       "time"
+
+	"github.com/botxlab/spotokn/internal"
 )
 
 
 const (
-	defaultPort  = 8080
-	readTimeout  = 10 * time.Second
-	writeTimeout = 10 * time.Second
-	idleTimeout  = 120 * time.Second
+	defaultPort        = 8080
+	readTimeout        = 10 * time.Second
+	writeTimeout       = 10 * time.Second
+	idleTimeout        = 120 * time.Second
+	errMethodNotAllowed = "Method not allowed"
 )
 
 type Server struct {
@@ -37,20 +39,40 @@ func NewServer() *Server {
 		logger:       logger,
 	}
 
-	mux.HandleFunc("/api/token", server.handleToken)
-	mux.HandleFunc("/health", server.handleHealth)
-	mux.HandleFunc("/", server.handleNotFound)
+			   mux.HandleFunc("/api/token", server.handleToken)
+			   mux.HandleFunc("/api/query", server.handleHash)
+			   mux.HandleFunc("/health", server.handleHealth)
+			   mux.HandleFunc("/", server.handleNotFound)
 
-	port := getEnvInt("PORT", defaultPort)
-	server.httpServer = &http.Server{
-		Addr:         ":" + strconv.Itoa(port),
-		Handler:      mux,
-		ReadTimeout:  readTimeout,
-		WriteTimeout: writeTimeout,
-		IdleTimeout:  idleTimeout,
-	}
+	       port := getEnvInt("PORT", defaultPort)
+	       server.httpServer = &http.Server{
+		       Addr:         ":" + strconv.Itoa(port),
+		       Handler:      mux,
+		       ReadTimeout:  readTimeout,
+		       WriteTimeout: writeTimeout,
+		       IdleTimeout:  idleTimeout,
+	       }
 
-	return server
+	       return server
+}
+
+// GET /api/query?playlist=spotify:playlist:ID
+func (s *Server) handleHash(w http.ResponseWriter, r *http.Request) {
+		       if r.Method != http.MethodGet {
+			       s.respondError(w, http.StatusMethodNotAllowed, errMethodNotAllowed)
+			       return
+		       }
+	       ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	       defer cancel()
+	       result, err := internal.GetSpotifyQueryResultFromRequest(ctx, r)
+	       if err != nil {
+		       s.logger.Error("Hash fetch failed: " + err.Error())
+		       s.respondError(w, http.StatusServiceUnavailable, "Could not get hash")
+		       return
+	       }
+	       w.Header().Set("Content-Type", "application/json")
+	       w.WriteHeader(http.StatusOK)
+	       json.NewEncoder(w).Encode(result)
 }
 
 func (s *Server) Start() error {
@@ -70,10 +92,10 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		s.respondError(w, http.StatusMethodNotAllowed, "Method not allowed")
-		return
-	}
+	       if r.Method != http.MethodGet {
+		       s.respondError(w, http.StatusMethodNotAllowed, errMethodNotAllowed)
+		       return
+	       }
 
 	query := r.URL.Query()
 	debug := query.Get("debug") == "true"
@@ -97,10 +119,10 @@ func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		s.respondError(w, http.StatusMethodNotAllowed, "Method not allowed")
-		return
-	}
+	       if r.Method != http.MethodGet {
+		       s.respondError(w, http.StatusMethodNotAllowed, errMethodNotAllowed)
+		       return
+	       }
 
 	health := map[string]interface{}{
 		"status":    "healthy",

--- a/internal/query.go
+++ b/internal/query.go
@@ -1,0 +1,130 @@
+
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+	"strconv"
+
+	"github.com/chromedp/chromedp"
+	"github.com/chromedp/cdproto/network"
+)
+
+type QueryResult struct {
+       Hash              string `json:"hash"`
+       SpotifyAppVersion string `json:"spotifyAppVersion"`
+       PayloadVersion    string `json:"payloadVersion"`
+}
+
+func GetSpotifyQueryResultFromRequest(ctx context.Context, r interface{}) (*QueryResult, error) {
+	if httpReq, ok := r.(*http.Request); ok {
+		 playlist := httpReq.URL.Query().Get("playlist")
+		 return GetSpotifyQueryResult(ctx, playlist)
+	}
+	return nil, errors.New("invalid request type")
+}
+
+// GetSpotifyQueryResult returns all info for the /api/query endpoint
+func GetSpotifyQueryResult(ctx context.Context, playlistURI string) (*QueryResult, error) {
+       if playlistURI == "" {
+	       playlistURI = "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"
+       }
+	browserBin := os.Getenv("HASH_BROWSER_BIN")
+	var allocCtx context.Context
+	var allocCancel context.CancelFunc
+	       if browserBin != "" {
+		       opts := append(chromedp.DefaultExecAllocatorOptions[:], chromedp.ExecPath(browserBin))
+		       allocCtx, allocCancel = chromedp.NewExecAllocator(ctx, opts...)
+	       } else {
+		       allocCtx, allocCancel = chromedp.NewExecAllocator(ctx, chromedp.DefaultExecAllocatorOptions[:]...)
+	       }
+	defer allocCancel()
+	ctx, cancel := chromedp.NewContext(allocCtx)
+	defer cancel()
+
+	var hash string
+	var appVersion string
+	var payloadVersion string
+	var found bool
+	var mu sync.Mutex
+	var targetRequestID network.RequestID
+
+			       chromedp.ListenTarget(ctx, func(ev interface{}) {
+				       if found {
+					       return
+				       }
+				       if e, ok := ev.(*network.EventRequestWillBeSent); ok {
+					       if strings.Contains(e.Request.URL, "/pathfinder/v2/query") && e.Request.Method == "POST" {
+						       mu.Lock()
+						       targetRequestID = e.RequestID
+							       for k, v := range e.Request.Headers {
+								       if strings.ToLower(k) == "spotify-app-version" {
+									       if vs, ok := v.(string); ok {
+										       appVersion = vs
+									       }
+								       }
+							       }
+						       mu.Unlock()
+					       }
+				       }
+			       })
+
+	playlistURL := "https://open.spotify.com/playlist/" + strings.TrimPrefix(playlistURI, "spotify:playlist:")
+
+	tasks := []chromedp.Action{
+		chromedp.Navigate(playlistURL),
+		chromedp.Sleep(500 * time.Millisecond),
+		chromedp.Click("button[data-testid='play-button']", chromedp.NodeVisible),
+		chromedp.Sleep(500 * time.Millisecond),
+	}
+		       err := chromedp.Run(ctx, tasks...)
+		       if err != nil {
+			       return nil, err
+		       }
+
+	mu.Lock()
+	reqID := targetRequestID
+	mu.Unlock()
+			       if reqID != "" {
+				       var postData string
+				       err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+					       pd, err := network.GetRequestPostData(reqID).Do(ctx)
+					       if err != nil {
+						       return err
+					       }
+					       postData = pd
+					       return nil
+				       }))
+				       if err == nil && postData != "" && strings.Contains(postData, "sha256Hash") {
+					       var payload map[string]interface{}
+					       if err := json.Unmarshal([]byte(postData), &payload); err == nil {
+						       if ext, ok := payload["extensions"].(map[string]interface{}); ok {
+							       if pq, ok := ext["persistedQuery"].(map[string]interface{}); ok {
+								       if h, ok := pq["sha256Hash"].(string); ok {
+									       hash = h
+									       found = true
+								       }
+								       if v, ok := pq["version"].(float64); ok {
+									       payloadVersion = strconv.Itoa(int(v))
+								       }
+							       }
+						       }
+					       }
+				       }
+			       }
+
+				       if !found {
+					       return nil, errors.New("hash not found")
+				       }
+				       return &QueryResult{
+					       Hash:              hash,
+					       SpotifyAppVersion: appVersion,
+					       PayloadVersion:    payloadVersion,
+				       }, nil
+}


### PR DESCRIPTION
Introduces a new /api/query HTTP endpoint to fetch Spotify playlist query hash and related metadata using a headless browser. Adds internal logic to extract the hash, Spotify app version, and payload version from network requests, supporting both standard and custom browser binaries.